### PR TITLE
FIX: 404 error in home "Learn More" button

### DIFF
--- a/src/app/(main)/(pages)/about/about-us/page.tsx
+++ b/src/app/(main)/(pages)/about/about-us/page.tsx
@@ -1,0 +1,12 @@
+import UnderConstruction from '@/components/ui/under-construction'
+import React from 'react'
+
+const AboutUs = () => {
+  return (
+    <div className="ext-3xl font-bold flex justify-center items-center min-h-[calc(100vh-140px)]">
+      <UnderConstruction />
+    </div>
+  )
+}
+
+export default AboutUs


### PR DESCRIPTION
Fix Learn More Button Link

Summary
This pull request addresses an issue where the "Learn More" button was pointing to a non-existent page (/about/about-us).

Changes Made
Created the /about/about-us page to resolve the broken link issue.
Added an "Under Construction" screen to the new /about/about-us page to inform users that the content is coming soon.
Details
The "Learn More" button on the homepage was leading users to a 404 error page because the /about/about-us route did not exist.
To ensure a better user experience, I created the missing /about/about-us page.
The new page currently displays an "Under Construction" screen to indicate that the content is not yet available but will be added soon.
Testing
Verified that the "Learn More" button now correctly navigates to the /about/about-us page.
Checked the display of the "Under Construction" screen to ensure it is informative and user-friendly.
Screenshots
![image](https://github.com/user-attachments/assets/f475edb9-20fc-4cc2-8174-0ec07cd90ae3)
