### PR TITLE
Created Privacy Policy page and updated some links

### DIFF
--- a/src/app/(main)/(pages)/about/privacy-policy/page.tsx
+++ b/src/app/(main)/(pages)/about/privacy-policy/page.tsx
@@ -1,0 +1,54 @@
+import PageHeader from '@/components/page-header'
+import PolicyContainer from '@/components/privacy-policy/policy-container'
+import React from 'react'
+
+
+
+const privacyPolicy =  [
+      {
+          title: "Introduction",
+          description: "Welcome to BUCC's Privacy Policy page. Your privacy is important to us. This policy explains how we collect, use, and protect your personal information when you visit our website or use our services."
+      },
+      {
+          title: "Information We Collect",
+          description: "We collect various types of information in order to provide you with the best possible experience. This includes personal information such as your name, email address, phone number, and any other details you voluntarily provide when you register on our site, subscribe to our newsletter, or fill out a form. Additionally, we automatically collect information about your interaction with our website, including your IP address, browser type, pages visited, time spent on the site, and other analytical data. We also use cookies and similar tracking technologies to enhance your experience, gather general visitor information, and track visits to our website."
+      },
+      {
+          title: "How We Use Your Information",
+          description: "The information we collect is used to improve our website, personalize your experience, process transactions, and send periodic emails. Your feedback and information help us respond to your individual needs and continually strive to enhance our offerings. Your personal information, whether public or private, will not be sold, exchanged, transferred, or given to any other company without your consent, except for the express purpose of delivering the purchased product or service requested. The email address you provide may be used to send you information, respond to inquiries, and address other requests or questions."
+      },
+      {
+          title: "Protection of Your Information",
+          description: "We implement a variety of security measures to maintain the safety of your personal information. These measures include password-protected directories and databases to safeguard your information, SSL (Secure Sockets Layered) technology to ensure that your information is fully encrypted and sent across the Internet securely, and regular security audits."
+      },
+      {
+          title: "Your Consent",
+          description: "By using our website, you consent to our Privacy Policy. We may update our Privacy Policy from time to time, and any changes will be posted on this page with the date updated accordingly. We encourage you to review this Privacy Policy periodically to stay informed about how we are protecting your information."
+      },
+      {
+          title: "Contact Us",
+          description: "If you have any questions about our Privacy Policy, please contact us at  info@bracucc.org , +8801717399105, or  Kha 226, Bir Uttam Rafiqul Islam Ave, Badda, Dhaka 1212 . Thank you for trusting BUCC with your personal information. We are committed to keeping it secure and respecting your privacy."
+      }
+  ]
+
+
+
+
+
+const PrivacyPolicyPage = () => {
+  return (
+    <div>
+      <PageHeader
+        title="Privacy Policy"        
+        description='Privacy Policies for BUCC Website'
+        />
+        <section className='p-5 md:p-10'>
+          <p className="font-semibold text-xl md:text-2xl">Last Updated: 15th July, 2024</p>
+          <p className='text-muted-foreground text-sm mt-3 mb-5'>Welcome to BUCC's Privacy Policy page. Your privacy is important to us. This policy explains how we collect, use, and protect your personal information when you visit our website or use our services.</p>
+          {privacyPolicy?.map((v,i)=><PolicyContainer key={i} {...v}/>)}
+        </section>
+    </div>
+  )
+}
+
+export default PrivacyPolicyPage

--- a/src/app/(main)/(pages)/about/terms-of-service/page.tsx
+++ b/src/app/(main)/(pages)/about/terms-of-service/page.tsx
@@ -1,0 +1,16 @@
+import PageHeader from '@/components/page-header'
+import UnderConstruction from '@/components/ui/under-construction'
+import React from 'react'
+
+const TermsOfServicePage = () => {
+  return (
+    <div>
+      {/* <PageHeader
+       title="Terms of Service"
+       description='Terms of Service for BUCC website'/> */}
+       <UnderConstruction/>
+    </div>
+  )
+}
+
+export default TermsOfServicePage

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -48,7 +48,7 @@ const footer_menu = [
     title: "Legal",
     childrens: [
       { title: "Terms of Use", path: "/tou" },
-      { title: "Privacy Policy", path: "/privacy-policy" },
+      { title: "Privacy Policy", path: "/about/privacy-policy" },
       { title: "Cookie Policy", path: "/cookie-policy" },
     ],
   },

--- a/src/components/privacy-policy/policy-container.tsx
+++ b/src/components/privacy-policy/policy-container.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+interface PolicyContainerProps{
+    title:string
+    description:string
+}
+const PolicyContainer = (props:PolicyContainerProps) => {
+  return (
+    <div className='my-10'>
+        <h1 className='text-lg md:text-xl font-bold'>{props.title}</h1>
+        <p className='mt-2 text-sm text-muted-foreground'>{props.description}</p>
+    </div>
+  )
+}
+
+export default PolicyContainer


### PR DESCRIPTION
Created the Privacy Policy page and fixed the link for the Privacy Policy page from /privacy-policy to /about/privacy-policy because the links were not the same in the footer on the home page and other pages.
